### PR TITLE
Bugfix configurePlugin for TYPO3 v11

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -1,4 +1,8 @@
 <?php
+
+use WebentwicklerAt\OpenidConnect\Controller\AuthenticationController;
+use WebentwicklerAt\OpenidConnect\Controller\RedirectController;
+
 defined('TYPO3_MODE') or die();
 
 (function () {
@@ -92,24 +96,24 @@ defined('TYPO3_MODE') or die();
 
     if ($extensionConfiguration['enableFrontendLogin']) {
         \TYPO3\CMS\Extbase\Utility\ExtensionUtility::configurePlugin(
-            'WebentwicklerAt.OpenidConnect',
+            'OpenidConnect',
             'Authentication',
             [
-                'Authentication' => 'index',
+                AuthenticationController::class => 'index',
             ],
             [
-                'Authentication' => 'index',
+                AuthenticationController::class => 'index',
             ]
         );
 
         \TYPO3\CMS\Extbase\Utility\ExtensionUtility::configurePlugin(
-            'WebentwicklerAt.OpenidConnect',
+            'OpenidConnect',
             'RedirectToLogin',
             [
-                'Redirect' => 'toLogin',
+                RedirectController::class => 'toLogin',
             ],
             [
-                'Redirect' => 'toLogin',
+                RedirectController::class => 'toLogin',
             ]
         );
     }


### PR DESCRIPTION
Fixes `Class Redirect not found` errors in TYPO3 v11.
according to https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/11.0/Breaking-92609-UseControllerClassesWhenRegisteringPluginsmodules.html

getting into a redirect loop when logging in currently, so most likely there is more work to do.
